### PR TITLE
Unzip using gz instead of xz

### DIFF
--- a/build-automake.sh
+++ b/build-automake.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-wget https://ftp.gnu.org/gnu/automake/automake-$AUTOMAKE_VERSION.tar.gz -O- | tar xz
+wget https://ftp.gnu.org/gnu/automake/automake-$AUTOMAKE_VERSION.tar.gz -O- | tar gz
 
 cd automake-$AUTOMAKE_VERSION
 


### PR DESCRIPTION
If using xz, I'm getting an error that the file is corrupt and it's not recoverable. Since the file extension is .gz I tried unzipping using gz and that works better.

Please test this well using your Docker image! I've tested the script on a CentOS 6.9 server but not inside your image.