### PR TITLE
Build and push Linux riscv64 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
             DIST: 'bionic'
           - ARCH: 'x86_64'
             DIST: 'bionic'
+          - ARCH: 'riscv64'
+            DIST: 'focal'
 
     name: Build ${{ matrix.DIST }}  (${{ matrix.ARCH }})
     env:

--- a/Dockerfile.focal-riscv64
+++ b/Dockerfile.focal-riscv64
@@ -1,0 +1,58 @@
+FROM riscv64/ubuntu:focal
+
+ENV ARCH=riscv64 DIST=focal
+
+# inherited by build scripts
+ARG VERBOSE=0
+
+COPY /entrypoint-ubuntu.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+SHELL ["/entrypoint.sh", "bash", "-c"]
+
+COPY ./install-deps-ubuntu.sh /
+RUN bash -x /install-deps-ubuntu.sh
+
+COPY ./install-cmake.sh /
+RUN bash -x /install-cmake.sh
+
+ARG DESKTOP_FILE_UTILS_VERSION=56d220dd679c7c3a8f995a41a27a7d6f3df49dea
+COPY build-desktop-file-utils.sh /
+RUN bash -x /build-desktop-file-utils.sh
+
+ARG AUTOMAKE_VERSION=1.16.5
+COPY build-automake.sh /
+RUN bash -x /build-automake.sh
+
+ARG LIBGPG_ERROR_VERSION=1.45
+COPY build-libgpg-error.sh /
+RUN bash -x /build-libgpg-error.sh
+
+ARG LIBASSUAN_VERSION=2.5.5
+COPY build-libassuan.sh /
+RUN bash -x /build-libassuan.sh
+
+ARG LIBGCRYPT_VERSION=1.10.1
+COPY build-libgcrypt.sh /
+RUN bash -x /build-libgcrypt.sh
+
+ARG LIBKSBA_VERSION=1.6.0
+COPY build-libksba.sh /
+RUN bash -x /build-libksba.sh
+
+ARG NPTH_VERSION=1.6
+COPY build-npth.sh /
+RUN bash -x /build-npth.sh
+
+ARG GNUPG_VERSION=2.3.7
+COPY build-gnupg.sh /
+RUN bash -x /build-gnupg.sh
+
+ARG GPGME_VERSION=1.17.1
+COPY build-gpgme.sh /
+RUN bash -x /build-gpgme.sh
+
+# create unprivileged user for non-build-script use of this image
+# build-in-docker.sh will likely not use this one, as it enforces the caller's uid inside the container
+RUN adduser --system --group build
+USER build


### PR DESCRIPTION
I wanted to use the AppImageKit on a Linux risc-v machine.

When trying to build it, I noticed that there were no `riscv64` images available.

As since Ubuntu is publishing riscv64 images, here is a AppImageBuild riscv64 suggestion, built in the same way as the aarch64 and armhf build images.

The base image focal is chosen as there are no riscv64 base image for bionic.

RISC-V is an open standard instruction set architecture, which is under rapid development. Distributions including AOSP, Arch Linux, Debian, Gentoo Linux, Fedora, OpenEuler, etc are also actively doing porting work for this architecture.

Here is a list of hardware available today: https://riscv.org/exchanges/boards/

I run and own a SiFive Unmatched.